### PR TITLE
feat: adicionado o conversor de ícones

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ node md2thf C:/pathFromMdFiles C:/pathToAngularFiles
 
 ### 1.1.0
 
-- **Nova Funcionalidade** na parte de conversão, agora ele irá converte os icones no padrão github para o html. Exemplo: "`:warning:`" será :warning:.
+- **Nova Funcionalidade** na parte de conversão, agora o md2thf irá converter os icones no padrão do Github para o html. 
+Exemplo: "`:warning:`" será :warning:.
 
 ### 1.0.2
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ node md2thf C:/pathFromMdFiles C:/pathToAngularFiles
 ### 1.1.0
 
 - **Nova Funcionalidade** na parte de conversão, agora o md2thf irá converter os icones no padrão do Github para o html. 
-Exemplo: "`:warning:`" será :warning:.
+Exemplo: `:warning:` será :warning:.
 
 ### 1.0.2
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# md2thf
+﻿# md2thf
 
 Conversor de arquivos `markdown` para componentes `Angular` utilizando recursos da biblioteca [`THF`][thf].
 
@@ -22,6 +22,10 @@ node md2thf C:/pathFromMdFiles C:/pathToAngularFiles
 ```
 
 ## Release Notes
+
+### 1.1.0
+
+- **Nova Funcionalidade** na parte de conversão, agora ele irá converte os icones no padrão github para o html. Exemplo: "`:warning:`" será :warning:.
 
 ### 1.0.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "md2thf",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -69,6 +69,12 @@
       "version": "12.0.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.8.tgz",
       "integrity": "sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==",
+      "dev": true
+    },
+    "@types/node-emoji": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/node-emoji/-/node-emoji-1.8.1.tgz",
+      "integrity": "sha512-0fRfA90FWm6KJfw6P9QGyo0HDTCmthZ7cWaBQndITlaWLTZ6njRyKwrwpzpg+n6kBXBIGKeUHEQuBx7bphGJkA==",
       "dev": true
     },
     "@types/sanitize-html": {
@@ -2569,6 +2575,12 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
       "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
     },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
@@ -2747,6 +2759,15 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "node-emoji": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
+      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "dev": true,
+      "requires": {
+        "lodash.toarray": "^4.4.0"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md2thf",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Conversor de arquivos `markdown` para páginas `Angular` que utilizam a biblioteca `THF`",
   "main": "dist/index.js",
   "scripts": {
@@ -37,10 +37,12 @@
     "@types/marked": "^0.6.5",
     "@types/mustache": "^0.8.32",
     "@types/node": "^12.0.2",
+    "@types/node-emoji": "^1.8.1",
     "@types/sanitize-html": "^1.20.0",
     "@types/uuid": "^3.4.4",
     "del": "^4.1.1",
     "gulp": "^4.0.2",
-    "gulp-uglify": "^3.0.2"
+    "gulp-uglify": "^3.0.2",
+    "node-emoji": "^1.10.0"
   }
 }

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -4,7 +4,7 @@ import mustache from 'mustache';
 import * as path from 'path';
 
 import { Component } from './component';
-import { Transform } from './helpers';
+import { Transform, TransformIcon } from './helpers';
 import { defaultOptions, Options } from './options';
 import { MarkdownFile, ThfRenderer } from './renderer';
 import * as templates from './templates';
@@ -112,7 +112,8 @@ export class Converter {
    * @returns Conteúdo da _view_ do componente renderizado.
    */
   private renderComponentView(component: Component) {
-    const content = marked(fs.readFileSync(component.getFile(), 'utf-8'), this.options);
+    const markdown = TransformIcon.convert(fs.readFileSync(component.getFile(), 'utf-8'));
+    const content = marked(markdown, this.options);
 
     component.setTitle(this.options.renderer.getTitle());
     return mustache.render(templates.componentView, { title: component.getTitle(), content });

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,1 +1,2 @@
 export * from './transform';
+export * from './transformIcon';

--- a/src/helpers/transformIcon.ts
+++ b/src/helpers/transformIcon.ts
@@ -1,0 +1,16 @@
+import emoji from 'node-emoji';
+
+export class TransformIcon {
+
+  /**
+   * Converte um icone delimitado por `:` (dois pontos) para o icone no padrão do github. 
+   * Exemplo: ":warning:" será "⚠️"
+   *
+   * @param text Texto a ser convertido
+   * @return Texto convertido.
+   */
+  public static convert(text: string): string {
+    const replacer = (match: string) => emoji.emojify(match);
+    return text.replace(/(:.*:)/g, replacer);
+  }
+}


### PR DESCRIPTION
Agora pode ser usado os ícones no padrão do github, ele irá converter.
Exemplo: "`:warning:`" será "⚠️".
